### PR TITLE
[Improvement/255] Adds an exception filter for all routes

### DIFF
--- a/__tests__/unit/middleware/denyPost.test.ts
+++ b/__tests__/unit/middleware/denyPost.test.ts
@@ -16,12 +16,10 @@ const mockedApiResponse = MockedApiResponse.mock()
 
 test('Expect that a request with a POST method fails', async () => {
 	const mockedApiRequest = MockedApiRequest.mock({}, 'POST')
-	const response = await handlerWithMiddleware(
-		mockedApiRequest,
-		mockedApiResponse
-	)
 
-	expect(response.error.message).toBe(onlyPostResponse.notAllowed('POST'))
+	expect(() =>
+		handlerWithMiddleware(mockedApiRequest, mockedApiResponse)
+	).toThrowError(onlyPostResponse.notAllowed('POST'))
 })
 
 test('Expect that a request with a GET method succeeds', async () => {

--- a/__tests__/unit/middleware/exceptionFilter.test.ts
+++ b/__tests__/unit/middleware/exceptionFilter.test.ts
@@ -3,11 +3,12 @@ import Response from 'src/response'
 import { testApiHandler } from 'next-test-api-route-handler'
 import StatusCode from 'src/constants/status'
 import language from 'src/constants/language'
+import exceptionFilter from 'src/middleware/exceptionFilter'
 
 describe('Response', () => {
 	it('responds with method not allowed', async () => {
 		await testApiHandler<{ message: string }>({
-			handler: (_, res) => Response.methodNotAllowed(res, 'GET'),
+			handler: exceptionFilter(() => Response.methodNotAllowed('GET')),
 			test: async ({ fetch }) => {
 				const res = await fetch()
 				expect(res.status).toBe(405)
@@ -21,7 +22,7 @@ describe('Response', () => {
 	it('responds with unauthorised', async () => {
 		const message = 'You are not authorised to access this resource'
 		await testApiHandler<{ message: string }>({
-			handler: (_, res) => Response.unauthorised(res, message),
+			handler: exceptionFilter(() => Response.unauthorised(message)),
 			test: async ({ fetch }) => {
 				const res = await fetch()
 				expect(res.status).toBe(401)
@@ -33,7 +34,9 @@ describe('Response', () => {
 	it('responds with unprocessible entity with error messages', async () => {
 		const errors = ['Should be an integer', 'Should be a string']
 		await testApiHandler<{ errors: string | Array<string> }>({
-			handler: (_, res) => Response.unprocessibleEntity(res, errors),
+			handler: exceptionFilter(() =>
+				Response.unprocessibleEntity(errors)
+			),
 			test: async ({ fetch }) => {
 				const res = await fetch()
 				expect(res.status).toBe(422)
@@ -47,7 +50,7 @@ describe('Response', () => {
 	})
 	it('responds with unprocessible entity', async () => {
 		await testApiHandler<{ errors: string | Array<string> }>({
-			handler: (_, res) => Response.unprocessibleEntity(res),
+			handler: exceptionFilter(() => Response.unprocessibleEntity()),
 			test: async ({ fetch }) => {
 				const res = await fetch()
 				expect(res.status).toBe(422)
@@ -61,7 +64,7 @@ describe('Response', () => {
 	})
 	it('responds with bad request', async () => {
 		await testApiHandler<null>({
-			handler: (_, res) => Response.badRequest(res),
+			handler: exceptionFilter(() => Response.badRequest()),
 			test: async ({ fetch }) => {
 				const res = await fetch()
 				expect(res.status).toBe(400)
@@ -75,7 +78,7 @@ describe('Response', () => {
 	it('responds with json', async () => {
 		const data = { foo: 'bar' }
 		await testApiHandler<{ data: Record<string, unknown> }>({
-			handler: (_, res) => Response.json(res, data),
+			handler: exceptionFilter((_, res) => Response.json(res, data)),
 			test: async ({ fetch }) => {
 				const res = await fetch()
 				expect(res.status).toBe(200)

--- a/__tests__/unit/middleware/onlyGet.test.ts
+++ b/__tests__/unit/middleware/onlyGet.test.ts
@@ -7,7 +7,7 @@ import onlyGet from 'src/middleware/onlyGet'
 // Mocks
 import MockedApiResponse from '@mocks/apiResponse'
 import MockedApiRequest from '@mocks/apiRequest'
-import GuardianApiError from 'src/utils/GuardianApiError'
+import GuardianMiddlewareApiError from 'src/utils/GuardianMiddlewareApiError'
 
 const { onlyPostResponse } = Language.middleware
 

--- a/__tests__/unit/middleware/onlyGet.test.ts
+++ b/__tests__/unit/middleware/onlyGet.test.ts
@@ -7,6 +7,7 @@ import onlyGet from 'src/middleware/onlyGet'
 // Mocks
 import MockedApiResponse from '@mocks/apiResponse'
 import MockedApiRequest from '@mocks/apiRequest'
+import GuardianApiError from 'src/utils/GuardianApiError'
 
 const { onlyPostResponse } = Language.middleware
 
@@ -26,10 +27,8 @@ test('Expect that a request with a GET method succeeds', async () => {
 
 test('Expect that a request with a POST method fails', async () => {
 	const mockedApiRequest = MockedApiRequest.mock({}, 'POST')
-	const response = await handlerWithMiddleware(
-		mockedApiRequest,
-		mockedApiResponse
-	)
 
-	expect(response.error.message).toBe(onlyPostResponse.notAllowed('POST'))
+	expect(() =>
+		handlerWithMiddleware(mockedApiRequest, mockedApiResponse)
+	).toThrowError(onlyPostResponse.notAllowed('POST'))
 })

--- a/__tests__/unit/middleware/onlyPost.test.ts
+++ b/__tests__/unit/middleware/onlyPost.test.ts
@@ -16,12 +16,10 @@ const mockedApiResponse = MockedApiResponse.mock()
 
 test('Expect that a request with a GET method fails', async () => {
 	const mockedApiRequest = MockedApiRequest.mock()
-	const response = await handlerWithMiddleware(
-		mockedApiRequest,
-		mockedApiResponse
-	)
 
-	expect(response.error.message).toBe(onlyPostResponse.notAllowed('GET'))
+	expect(() =>
+		handlerWithMiddleware(mockedApiRequest, mockedApiResponse)
+	).toThrowError(onlyPostResponse.notAllowed('GET'))
 })
 
 test('Expect that a request with a POST method succeeds', async () => {

--- a/__tests__/unit/middleware/withAuthentication.test.ts
+++ b/__tests__/unit/middleware/withAuthentication.test.ts
@@ -16,14 +16,10 @@ const mockedApiResponse = MockedApiResponse.mock()
 
 test('Expect that a request with no authorization header fails', async () => {
 	const mockedApiRequest = MockedApiRequest.mock()
-	const response = await handlerWithMiddleware(
-		mockedApiRequest,
-		mockedApiResponse
-	)
 
-	expect(response.error.message).toBe(
-		withAuthenticationResponse.noAccessToken
-	)
+	expect(() =>
+		handlerWithMiddleware(mockedApiRequest, mockedApiResponse)
+	).toThrowError(withAuthenticationResponse.noAccessToken)
 })
 
 test('Expect that a request with a JWT is successfull', async () => {

--- a/pages/api/accounts/index.ts
+++ b/pages/api/accounts/index.ts
@@ -4,8 +4,10 @@ import CreateAccountHandler from 'src/handler/accounts/createAccountHandler'
 import useGuardianContext from 'src/context/useGuardianContext'
 import useHashgraphContext from 'src/context/useHashgraphContext'
 import withHmac from 'src/middleware/withHmac'
+import exceptionFilter from 'src/middleware/exceptionFilter'
 
 export default prepare(
+	exceptionFilter,
 	onlyPost,
 	withHmac,
 	useGuardianContext,

--- a/pages/api/accounts/login.ts
+++ b/pages/api/accounts/login.ts
@@ -3,5 +3,11 @@ import loginHandler from 'src/handler/accounts/loginHandler'
 import useGuardianContext from 'src/context/useGuardianContext'
 import onlyPost from 'src/middleware/onlyPost'
 import withHmac from 'src/middleware/withHmac'
+import exceptionFilter from 'src/middleware/exceptionFilter'
 
-export default prepare(onlyPost, withHmac, useGuardianContext)(loginHandler)
+export default prepare(
+	exceptionFilter,
+	onlyPost,
+	withHmac,
+	useGuardianContext
+)(loginHandler)

--- a/pages/api/policies/[policyId]/approve/application/[did].ts
+++ b/pages/api/policies/[policyId]/approve/application/[did].ts
@@ -6,8 +6,10 @@ import withAuthentication from 'src/middleware/withAuthentication'
 import withHmac from 'src/middleware/withHmac'
 import ensureRole from 'src/middleware/ensureRole'
 import { Role } from 'src/config'
+import exceptionFilter from 'src/middleware/exceptionFilter'
 
 export default prepare(
+	exceptionFilter,
 	onlyPut,
 	withHmac,
 	useGuardianContext,

--- a/pages/api/policies/[policyId]/approve/mrv/[did].ts
+++ b/pages/api/policies/[policyId]/approve/mrv/[did].ts
@@ -6,8 +6,10 @@ import withAuthentication from 'src/middleware/withAuthentication'
 import withHmac from 'src/middleware/withHmac'
 import ensureRole from 'src/middleware/ensureRole'
 import { Role } from 'src/config'
+import exceptionFilter from 'src/middleware/exceptionFilter'
 
 export default prepare(
+	exceptionFilter,
 	onlyPut,
 	withHmac,
 	useGuardianContext,

--- a/pages/api/policies/[policyId]/approve/project/[did].ts
+++ b/pages/api/policies/[policyId]/approve/project/[did].ts
@@ -6,8 +6,10 @@ import withAuthentication from 'src/middleware/withAuthentication'
 import withHmac from 'src/middleware/withHmac'
 import ensureRole from 'src/middleware/ensureRole'
 import { Role } from 'src/config'
+import exceptionFilter from 'src/middleware/exceptionFilter'
 
 export default prepare(
+	exceptionFilter,
 	onlyPut,
 	withHmac,
 	useGuardianContext,

--- a/pages/api/policies/[policyId]/mrv/[mrvType].ts
+++ b/pages/api/policies/[policyId]/mrv/[mrvType].ts
@@ -6,8 +6,10 @@ import withAuthentication from 'src/middleware/withAuthentication'
 import withHmac from 'src/middleware/withHmac'
 import ensureRole from 'src/middleware/ensureRole'
 import { Role } from 'src/config'
+import exceptionFilter from 'src/middleware/exceptionFilter'
 
 export default prepare(
+	exceptionFilter,
 	onlyPost,
 	withHmac,
 	useGuardianContext,

--- a/pages/api/policies/[policyId]/project/index.ts
+++ b/pages/api/policies/[policyId]/project/index.ts
@@ -6,8 +6,10 @@ import withAuthentication from 'src/middleware/withAuthentication'
 import withHmac from 'src/middleware/withHmac'
 import ensureRole from 'src/middleware/ensureRole'
 import { Role } from 'src/config'
+import exceptionFilter from 'src/middleware/exceptionFilter'
 
 export default prepare(
+	exceptionFilter,
 	onlyPost,
 	withHmac,
 	useGuardianContext,

--- a/pages/api/policies/[policyId]/register/index.ts
+++ b/pages/api/policies/[policyId]/register/index.ts
@@ -6,8 +6,10 @@ import withAuthentication from 'src/middleware/withAuthentication'
 import withHmac from 'src/middleware/withHmac'
 import ensureRole from 'src/middleware/ensureRole'
 import { Role } from 'src/config'
+import exceptionFilter from 'src/middleware/exceptionFilter'
 
 export default prepare(
+	exceptionFilter,
 	onlyPost,
 	withHmac,
 	useGuardianContext,

--- a/pages/api/policies/[policyId]/role/[roleType].ts
+++ b/pages/api/policies/[policyId]/role/[roleType].ts
@@ -4,8 +4,10 @@ import useGuardianContext from 'src/context/useGuardianContext'
 import registerAccountToPolicyHandler from 'src/handler/policies/registerAccountToPolicyHandler'
 import withAuthentication from 'src/middleware/withAuthentication'
 import withHmac from 'src/middleware/withHmac'
+import exceptionFilter from 'src/middleware/exceptionFilter'
 
 export default prepare(
+	exceptionFilter,
 	onlyPost,
 	withHmac,
 	useGuardianContext,

--- a/pages/api/testAuth.ts
+++ b/pages/api/testAuth.ts
@@ -1,5 +1,6 @@
 import prepare from 'src/utils/prepare'
 import TestAuthHandler from 'src/handler/testAuthHandler'
 import withHmac from 'src/middleware/withHmac'
+import exceptionFilter from 'src/middleware/exceptionFilter'
 
-export default prepare(withHmac)(TestAuthHandler)
+export default prepare(exceptionFilter, withHmac)(TestAuthHandler)

--- a/src/constants/language/index.ts
+++ b/src/constants/language/index.ts
@@ -33,10 +33,27 @@ const language = {
 		},
 		validate: {
 			message: 'Validation errors',
+			invalidRole:
+				"Invalid role type. Must be 'registrant' or 'verifier'",
 		},
 		guardian: {
 			serverError:
 				'💥 Guardian API server error… your guess is as good as ours… 🤷‍♂️',
+		},
+		hmac: {
+			noHost: 'Missing "host" in header',
+			noSignature: 'Missing HMAC "x-signature" in header',
+			noDate: 'Missing "x-date" in header',
+			invalidDate:
+				'"x-date" header should be an ISO 8601 UTC date string',
+			noContentHash:
+				'Missing "x-content-sha256" in header. This should be a base64 encoded sha256 hash of the request body',
+			requestTooOld:
+				'Request "x-date" is too old. Please re-create the request.',
+			invalidContentHash:
+				'Request body hash does not match the hash provided in the header for "x-content-sha256"',
+			invalidSignature:
+				'HMAC signature is invalid. Please make sure you are using the correct key and following the correct format.',
 		},
 	},
 

--- a/src/handler/accounts/createAccountHandler.ts
+++ b/src/handler/accounts/createAccountHandler.ts
@@ -1,6 +1,5 @@
 import Response from 'src/response'
 import { NextApiResponse } from 'next'
-import language from 'src/constants/language'
 import validateCredentials from 'src/validators/validateCredentials'
 import { components } from 'src/spec/openapi'
 import { CreateAccountDto } from 'src/guardian/account'

--- a/src/handler/accounts/createAccountHandler.ts
+++ b/src/handler/accounts/createAccountHandler.ts
@@ -23,7 +23,7 @@ async function CreateAccountHandler(
 	const validationErrors = validateCredentials(userCredentials)
 
 	if (validationErrors) {
-		Response.unprocessibleEntity(res, validationErrors)
+		Response.unprocessibleEntity(validationErrors)
 		return
 	}
 
@@ -33,31 +33,27 @@ async function CreateAccountHandler(
 		role: 'USER',
 	}
 
-	try {
-		await guardian.account.register(userData)
+	await guardian.account.register(userData)
 
-		const loginUser = await guardian.account.login(userCredentials)
+	const loginUser = await guardian.account.login(userCredentials)
 
-		const { accountId, privateKey } = await hashgraphClient.createAccount()
+	const { accountId, privateKey } = await hashgraphClient.createAccount()
 
-		const userProfile = {
-			hederaAccountId: accountId,
-			hederaAccountKey: privateKey,
-		}
-
-		await guardian.profile.save(
-			loginUser.accessToken,
-			userProfile,
-			userCredentials.username
-		)
-
-		// The DID is missing from the initial login call so we call again to saturate the DID before returning the response
-		const accountData = await guardian.account.login(userCredentials)
-
-		Response.json(res, accountData)
-	} catch (error) {
-		Response.serverError(res, error)
+	const userProfile = {
+		hederaAccountId: accountId,
+		hederaAccountKey: privateKey,
 	}
+
+	await guardian.profile.save(
+		loginUser.accessToken,
+		userProfile,
+		userCredentials.username
+	)
+
+	// The DID is missing from the initial login call so we call again to saturate the DID before returning the response
+	const accountData = await guardian.account.login(userCredentials)
+
+	Response.json(res, accountData)
 }
 
 export default CreateAccountHandler

--- a/src/handler/accounts/loginHandler.ts
+++ b/src/handler/accounts/loginHandler.ts
@@ -2,7 +2,6 @@ import { GuardianMiddlewareRequest } from 'src/context/useGuardianContext'
 import Response from 'src/response'
 import { NextApiResponse } from 'next'
 import validateCredentials from 'src/validators/validateCredentials'
-import language from 'src/constants/language'
 import { components } from 'src/spec/openapi'
 
 type Credentials = components['schemas']['Credentials']
@@ -19,7 +18,7 @@ async function loginHandler(req: LoginRequest, res: NextApiResponse) {
 	const validationErrors = validateCredentials(userCredentials)
 
 	if (validationErrors) {
-		Response.unprocessibleEntity(res, validationErrors)
+		Response.unprocessibleEntity(validationErrors)
 		return
 	}
 

--- a/src/handler/policies/approveApplicationHandler.ts
+++ b/src/handler/policies/approveApplicationHandler.ts
@@ -30,7 +30,7 @@ async function ApproveApplicationHandler(
 	)
 
 	if (!document) {
-		return Response.notFound(res)
+		return Response.notFound()
 	}
 
 	const submission = {

--- a/src/handler/policies/approveEcologicalProjectHandler.ts
+++ b/src/handler/policies/approveEcologicalProjectHandler.ts
@@ -24,7 +24,7 @@ async function ApproveEcologicalProjectHandler(
 	)
 
 	if (!document) {
-		return Response.notFound(res)
+		return Response.notFound()
 	}
 
 	const submission = {

--- a/src/handler/policies/approveMrvRequestHandler.ts
+++ b/src/handler/policies/approveMrvRequestHandler.ts
@@ -24,7 +24,7 @@ async function ApproveMrvRequestHandler(
 	)
 
 	if (!document) {
-		return Response.notFound(res)
+		return Response.notFound()
 	}
 
 	const submission = {

--- a/src/handler/policies/ecologicalProjectHandler.ts
+++ b/src/handler/policies/ecologicalProjectHandler.ts
@@ -23,7 +23,7 @@ async function EcologicalProjectHandler(
 	const validationErrors = validateEcologicalProjectSubmission(body)
 
 	if (validationErrors) {
-		return Response.unprocessibleEntity(res, validationErrors)
+		return Response.unprocessibleEntity(validationErrors)
 	}
 
 	const did = await engine.getCurrentUserDid(accessToken)

--- a/src/handler/policies/ecologicalProjectHandler.ts
+++ b/src/handler/policies/ecologicalProjectHandler.ts
@@ -35,7 +35,7 @@ async function EcologicalProjectHandler(
 	)
 
 	if (!previousDocument) {
-		return Response.notFound(res)
+		return Response.notFound()
 	}
 
 	const data = {

--- a/src/handler/policies/mrvSubmissionHandler.ts
+++ b/src/handler/policies/mrvSubmissionHandler.ts
@@ -36,7 +36,7 @@ async function MrvSubmissionHandler(req: MRVRequest, res: NextApiResponse) {
 	)
 
 	if (!previousDocument) {
-		return Response.notFound(res)
+		return Response.notFound()
 	}
 
 	const data = {

--- a/src/handler/policies/mrvSubmissionHandler.ts
+++ b/src/handler/policies/mrvSubmissionHandler.ts
@@ -24,7 +24,7 @@ async function MrvSubmissionHandler(req: MRVRequest, res: NextApiResponse) {
 	)
 
 	if (validationErrors) {
-		return Response.unprocessibleEntity(res, validationErrors)
+		return Response.unprocessibleEntity(validationErrors)
 	}
 
 	const did = await engine.getCurrentUserDid(accessToken)

--- a/src/handler/policies/registerAccountToPolicyHandler.ts
+++ b/src/handler/policies/registerAccountToPolicyHandler.ts
@@ -2,6 +2,7 @@ import { GuardianMiddlewareRequest } from 'src/context/useGuardianContext'
 import Response from 'src/response'
 import Config, { Role } from 'src/config'
 import { NextApiResponse } from 'next'
+import language from 'src/constants/language'
 
 async function RegisterAccountToPolicyHandler(
 	req: GuardianMiddlewareRequest,
@@ -13,9 +14,9 @@ async function RegisterAccountToPolicyHandler(
 	const role = (roleType as string)?.toUpperCase()
 
 	if (role !== Role.REGISTRANT && role !== Role.VERIFIER) {
-		return Response.unprocessibleEntity(res, [
-			"Invalid role type. Must be 'registrant' or 'verifier'",
-		])
+		return Response.unprocessibleEntity(
+			language.middleware.validate.invalidRole
+		)
 	}
 
 	const tag = Config.tags.chooseRole

--- a/src/handler/policies/registerProjectHandler.ts
+++ b/src/handler/policies/registerProjectHandler.ts
@@ -22,7 +22,7 @@ async function RegisterProjectHandler(
 	const validationErrors = validateProjectRegistrationApplication(body)
 
 	if (validationErrors) {
-		Response.unprocessibleEntity(res, validationErrors)
+		Response.unprocessibleEntity(validationErrors)
 		return
 	}
 

--- a/src/hashgraph/hashgraphClient.ts
+++ b/src/hashgraph/hashgraphClient.ts
@@ -16,17 +16,17 @@ const client = () => {
 	const { network, accountId, privateKey } = config
 
 	if (!network) {
-		throw Error(
+		throw new Error(
 			`Network from environment could not match for any hedera network. Change your "HEDERA_NETWORK" environment variable to either: "testnet", "previewnet" or "mainnet"`
 		)
 	}
 	if (!accountId) {
-		throw Error(
+		throw new Error(
 			`Account ID from environment could not match for any hedera network. Change your "HEDERA_OPERATOR_ACCOUNT_ID" environment variable to a valid hedera account id`
 		)
 	}
 	if (!privateKey) {
-		throw Error(
+		throw new Error(
 			`Private key from environment could not match for any hedera network. Change your "HEDERA_OPERATOR_PRIVATE_KEY" environment variable to a valid hedera private key`
 		)
 	}

--- a/src/middleware/denyPost.ts
+++ b/src/middleware/denyPost.ts
@@ -5,7 +5,7 @@ import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next'
 function denyPost(handler: NextApiHandler) {
 	return (req: NextApiRequest, res: NextApiResponse) => {
 		if (req.method === Request.POST) {
-			return Response.methodNotAllowed(res, req.method)
+			return Response.methodNotAllowed(req.method)
 		}
 
 		return handler(req, res)

--- a/src/middleware/ensureEncryptionKey.ts
+++ b/src/middleware/ensureEncryptionKey.ts
@@ -13,7 +13,7 @@ function ensureEncryptionKey(handler: NextApiHandler) {
 			return handler(req, res)
 		}
 
-		return Response.unprocessibleEntity(res, [noEncryptionKey])
+		return Response.unprocessibleEntity(noEncryptionKey)
 	}
 }
 

--- a/src/middleware/ensureRole.ts
+++ b/src/middleware/ensureRole.ts
@@ -16,24 +16,24 @@ const ensureRole =
 			Language.middleware
 
 		if (!policyId) {
-			return Response.unprocessibleEntity(res, [
-				ensureRoleMessage.policyRequired,
-			])
+			return Response.unprocessibleEntity(
+				ensureRoleMessage.policyRequired
+			)
 		}
 
 		if (!accessToken) {
-			return Response.unprocessibleEntity(res, [
-				withAuthenticationResponse.noAccessToken,
-			])
+			return Response.unprocessibleEntity(
+				withAuthenticationResponse.noAccessToken
+			)
 		}
 
 		const policies = await guardian.policies.list(accessToken)
 		const policy = policies.find((p) => p.id === policyId)
 
 		if (!policy) {
-			return Response.unprocessibleEntity(res, [
-				ensureRoleMessage.policyDoesNotExist,
-			])
+			return Response.unprocessibleEntity(
+				ensureRoleMessage.policyDoesNotExist
+			)
 		}
 
 		// @ts-ignore TODO: Policy needs typing
@@ -45,7 +45,7 @@ const ensureRole =
 			return handler(req, res)
 		}
 
-		return Response.unauthorised(res, ensureRoleMessage[role])
+		return Response.unauthorised(ensureRoleMessage[role])
 	}
 
 export default ensureRole

--- a/src/middleware/exceptionFilter.ts
+++ b/src/middleware/exceptionFilter.ts
@@ -1,0 +1,85 @@
+import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next'
+import { ApiError } from 'next/dist/server/api-utils'
+import StatusCode from 'src/constants/status'
+import { components } from 'src/spec/openapi'
+import GuardianApiError from 'src/utils/GuardianApiError'
+
+type ErrorApiResponse = components['schemas']['ErrorResponse']
+
+function getExceptionStatus(exception: unknown) {
+	return exception instanceof ApiError
+		? exception.statusCode
+		: StatusCode.INTERNAL_SERVER_ERROR
+}
+
+function getExceptionErrors(exception: unknown) {
+	return exception instanceof GuardianApiError ? exception.errors : undefined
+}
+
+function getExceptionMessage(exception: unknown) {
+	return isError(exception) ? exception.message : `Internal Server Error`
+}
+
+function getExceptionStack(exception: unknown) {
+	return isError(exception) ? exception.stack : undefined
+}
+
+function isError(exception: unknown): exception is Error {
+	return exception instanceof Error
+}
+
+function exceptionFilter(handler: NextApiHandler) {
+	return async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+		try {
+			await handler(req, res)
+		} catch (exception) {
+			const { url, headers } = req
+
+			const statusCode = getExceptionStatus(exception)
+			const message = getExceptionMessage(exception)
+			const stack = getExceptionStack(exception)
+			const errors = getExceptionErrors(exception)
+
+			// @ts-ignore
+			const auth = req.accessToken ?? 'Not Authenticated'
+
+			const { referer } = headers
+			const userAgent = headers['user-agent']
+
+			const requestContext = {
+				url,
+				auth,
+				referer,
+				userAgent,
+				message,
+				errors,
+			}
+
+			if (statusCode === StatusCode.INTERNAL_SERVER_ERROR) {
+				console.error(requestContext)
+			} else {
+				console.debug(requestContext)
+			}
+
+			if (stack) {
+				console.debug(stack)
+			}
+
+			const timestamp = new Date().toISOString()
+
+			const responseBody: ErrorApiResponse = {
+				error: {
+					message,
+					statusCode,
+					timestamp,
+					path: req.url,
+					...(errors ? { errors } : {}),
+				},
+			}
+
+			res.status(statusCode).send(responseBody)
+		}
+	}
+}
+
+export default exceptionFilter

--- a/src/middleware/onlyGet.ts
+++ b/src/middleware/onlyGet.ts
@@ -8,7 +8,7 @@ function onlyGet(handler: NextApiHandler) {
 			return handler(req, res)
 		}
 
-		return Response.methodNotAllowed(res, req.method)
+		return Response.methodNotAllowed(req.method)
 	}
 }
 

--- a/src/middleware/onlyPost.ts
+++ b/src/middleware/onlyPost.ts
@@ -8,7 +8,7 @@ function onlyPost(handler: NextApiHandler) {
 			return handler(req, res)
 		}
 
-		return Response.methodNotAllowed(res, req.method)
+		return Response.methodNotAllowed(req.method)
 	}
 }
 

--- a/src/middleware/onlyPut.ts
+++ b/src/middleware/onlyPut.ts
@@ -8,7 +8,7 @@ function onlyPut(handler: NextApiHandler) {
 			return handler(req, res)
 		}
 
-		return Response.methodNotAllowed(res, req.method)
+		return Response.methodNotAllowed(req.method)
 	}
 }
 

--- a/src/middleware/withAuthentication.ts
+++ b/src/middleware/withAuthentication.ts
@@ -14,17 +14,17 @@ function withAuthentication(handler: NextApiHandler) {
 		const { authorization } = req.headers
 
 		if (!authorization) {
-			return Response.unauthorised(res, noAccessToken)
+			return Response.unauthorised(noAccessToken)
 		}
 
 		const [type, accessToken] = authorization?.split(' ') || []
 
 		if (type?.toLowerCase() !== 'bearer') {
-			return Response.unauthorised(res, invalidAuthType(type))
+			return Response.unauthorised(invalidAuthType(type))
 		}
 
 		if (!accessToken) {
-			return Response.unauthorised(res, noAccessToken)
+			return Response.unauthorised(noAccessToken)
 		}
 
 		req.accessToken = accessToken

--- a/src/response/index.ts
+++ b/src/response/index.ts
@@ -1,12 +1,12 @@
 import Language from 'src/constants/language'
 import StatusCode from 'src/constants/status'
 import { NextApiResponse } from 'next'
-import GuardianApiError from 'src/utils/GuardianApiError'
+import GuardianMiddlewareApiError from 'src/utils/GuardianMiddlewareApiError'
 
 const { notAllowed } = Language.middleware.onlyPostResponse
 
 function methodNotAllowed(method: string) {
-	throw new GuardianApiError(
+	throw new GuardianMiddlewareApiError(
 		StatusCode.METHOD_NOT_ALLOWED,
 		notAllowed(method)
 	)
@@ -17,7 +17,7 @@ function unauthorised(message: string) {
 }
 
 function unprocessibleEntity(errors?: string | Array<string>) {
-	throw new GuardianApiError(
+	throw new GuardianMiddlewareApiError(
 		StatusCode.UNPROCESSIBLE_ENTITY,
 		Language.errorCode[StatusCode.UNPROCESSIBLE_ENTITY],
 		errors && (errors instanceof Array ? errors : [errors])
@@ -33,7 +33,7 @@ function notFound() {
 }
 
 function errorResponse(statusCode: StatusCode, message?: string) {
-	throw new GuardianApiError(
+	throw new GuardianMiddlewareApiError(
 		statusCode,
 		message || Language.errorCode[statusCode]
 	)

--- a/src/response/index.ts
+++ b/src/response/index.ts
@@ -6,36 +6,38 @@ import GuardianMiddlewareApiError from 'src/utils/GuardianMiddlewareApiError'
 const { notAllowed } = Language.middleware.onlyPostResponse
 
 function methodNotAllowed(method: string) {
-	throw new GuardianMiddlewareApiError(
-		StatusCode.METHOD_NOT_ALLOWED,
-		notAllowed(method)
-	)
+	throwApiError(StatusCode.METHOD_NOT_ALLOWED, notAllowed(method))
 }
 
 function unauthorised(message: string) {
-	errorResponse(StatusCode.UNAUTHORIZED, message)
+	throwApiError(StatusCode.UNAUTHORIZED, message)
 }
 
 function unprocessibleEntity(errors?: string | Array<string>) {
-	throw new GuardianMiddlewareApiError(
+	throwApiError(
 		StatusCode.UNPROCESSIBLE_ENTITY,
 		Language.errorCode[StatusCode.UNPROCESSIBLE_ENTITY],
-		errors && (errors instanceof Array ? errors : [errors])
+		errors
 	)
 }
 
 function badRequest() {
-	errorResponse(StatusCode.BAD_REQUEST)
+	throwApiError(StatusCode.BAD_REQUEST)
 }
 
 function notFound() {
-	errorResponse(StatusCode.NOT_FOUND)
+	throwApiError(StatusCode.NOT_FOUND)
 }
 
-function errorResponse(statusCode: StatusCode, message?: string) {
+function throwApiError(
+	statusCode: StatusCode,
+	message?: string,
+	errors?: string | Array<string>
+) {
 	throw new GuardianMiddlewareApiError(
 		statusCode,
-		message || Language.errorCode[statusCode]
+		message || Language.errorCode[statusCode],
+		errors && (errors instanceof Array ? errors : [errors])
 	)
 }
 

--- a/src/spec/openapi.json
+++ b/src/spec/openapi.json
@@ -53,7 +53,7 @@
 				"content": {
 					"application/json": {
 						"schema": {
-							"$ref": "#/components/schemas/UnprocessableErrorResponse"
+							"$ref": "#/components/schemas/ErrorResponse"
 						}
 					}
 				}
@@ -122,8 +122,29 @@
 						"properties": {
 							"message": {
 								"type": "string"
+							},
+							"statusCode": {
+								"type": "number"
+							},
+							"timestamp": {
+								"type": "string"
+							},
+							"path": {
+								"type": "string"
+							},
+							"errors": {
+								"type": "array",
+								"items": {
+									"type": "string"
+								}
 							}
-						}
+						},
+						"required": [
+							"message",
+							"statusCode",
+							"timestamp",
+							"path"
+						]
 					}
 				}
 			},

--- a/src/spec/openapi.ts
+++ b/src/spec/openapi.ts
@@ -263,7 +263,11 @@ export interface components {
 		}
 		ErrorResponse: {
 			error?: {
-				message?: string
+				message: string
+				statusCode: number
+				timestamp: string
+				path: string
+				errors?: string[]
 			}
 		}
 		UnprocessableErrorResponse: {
@@ -423,7 +427,7 @@ export interface components {
 		/** Unprocessable entity */
 		422: {
 			content: {
-				'application/json': components['schemas']['UnprocessableErrorResponse']
+				'application/json': components['schemas']['ErrorResponse']
 			}
 		}
 	}

--- a/src/utils/GuardianApiError.ts
+++ b/src/utils/GuardianApiError.ts
@@ -1,0 +1,14 @@
+import { ApiError } from 'next/dist/server/api-utils'
+
+export default class GuardianApiError extends ApiError {
+	readonly errors: Array<string> | undefined
+
+	constructor(
+		statusCode: number,
+		message: string,
+		errors: Array<string> | undefined = undefined
+	) {
+		super(statusCode, message)
+		this.errors = errors
+	}
+}

--- a/src/utils/GuardianMiddlewareApiError.ts
+++ b/src/utils/GuardianMiddlewareApiError.ts
@@ -1,6 +1,6 @@
 import { ApiError } from 'next/dist/server/api-utils'
 
-export default class GuardianApiError extends ApiError {
+export default class GuardianMiddlewareApiError extends ApiError {
 	readonly errors: Array<string> | undefined
 
 	constructor(

--- a/src/utils/hmac.ts
+++ b/src/utils/hmac.ts
@@ -3,7 +3,7 @@ import Crypto from 'crypto'
 
 function generateHmac(payloadAsString: string): string {
 	if (typeof payloadAsString !== 'string') {
-		throw Error('Your payload object must be converted in to a string')
+		throw new Error('Your payload object must be converted in to a string')
 	}
 
 	return Crypto.createHmac('sha256', config.hmacAuthKey)


### PR DESCRIPTION
This PR updates how we raise errors in the API layer.

Make sure to add the new `exceptionFilter` to any new route and then you can be guaranteed that all exceptions will be caught and handled appropriately.

Previously we called the response object directly like this for every single error type we wanted to send.
`res.status(404).send({error: {message:"Not Found"}})`

Now we make use of a global exception handler and throw `GuardianMiddlewareApiError`s instead.

At the lowest level, this is the function which throws the error. It lets us add all the relevant information we require for constructing a response in the exception handler.
```
function throwApiError(
	statusCode: StatusCode,
	message?: string,
	errors?: string | Array<string>
) {
	throw new GuardianMiddlewareApiError(
		statusCode,
		message || Language.errorCode[statusCode],
		errors && (errors instanceof Array ? errors : [errors])
	)
}
```
We then provide abstractions on this for simple access such as
```
function notFound() {
	throwApiError(StatusCode.NOT_FOUND)
}
```
Then in our code we just call
```
Response.notFound()
```
This will throw and then be caught in our `src/middleware/exceptionFilter.ts` which is responsible for inspecting the error and then producing a suitable response.