### PR TITLE
[Feature] Enables a public Trust Chain endpoint

### DIFF
--- a/env.example
+++ b/env.example
@@ -19,6 +19,10 @@ TEST_AUTH_URL=http://localhost:3000/api/testAuth
 STANDARD_REGISTRY_USERNAME=dovuauthority
 STANDARD_REGISTRY_PASSWORD=123
 
+# Set to TRUE to enable public access to the trust chain endpoint /policies/:policyId/trustchains
+# This removes the need for HMAC authentication or a role to access the trust chain endpoint
+PUBLIC_TRUST_CHAIN_ACCESS=TRUE
+
 # These are used for end to end tests of the API. Make sure to add these to your .env.test.local file
 TEST_COOL_FARM_POLICY_ID=62f2365b7fe3fa7b888e846d
 TEST_AGRECALC_POLICY_ID=62f27a007fe3fa7b888e8496

--- a/pages/api/accounts/index.ts
+++ b/pages/api/accounts/index.ts
@@ -4,10 +4,8 @@ import CreateAccountHandler from 'src/handler/accounts/createAccountHandler'
 import useGuardianContext from 'src/context/useGuardianContext'
 import useHashgraphContext from 'src/context/useHashgraphContext'
 import withHmac from 'src/middleware/withHmac'
-import exceptionFilter from 'src/middleware/exceptionFilter'
 
 export default prepare(
-	exceptionFilter,
 	onlyPost,
 	withHmac,
 	useGuardianContext,

--- a/pages/api/accounts/login.ts
+++ b/pages/api/accounts/login.ts
@@ -3,11 +3,5 @@ import loginHandler from 'src/handler/accounts/loginHandler'
 import useGuardianContext from 'src/context/useGuardianContext'
 import onlyPost from 'src/middleware/onlyPost'
 import withHmac from 'src/middleware/withHmac'
-import exceptionFilter from 'src/middleware/exceptionFilter'
 
-export default prepare(
-	exceptionFilter,
-	onlyPost,
-	withHmac,
-	useGuardianContext
-)(loginHandler)
+export default prepare(onlyPost, withHmac, useGuardianContext)(loginHandler)

--- a/pages/api/policies/[policyId]/approve/application/[did].ts
+++ b/pages/api/policies/[policyId]/approve/application/[did].ts
@@ -6,10 +6,8 @@ import withAuthentication from 'src/middleware/withAuthentication'
 import withHmac from 'src/middleware/withHmac'
 import ensureRole from 'src/middleware/ensureRole'
 import { Role } from 'src/config/guardianTags'
-import exceptionFilter from 'src/middleware/exceptionFilter'
 
 export default prepare(
-	exceptionFilter,
 	onlyPut,
 	withHmac,
 	useGuardianContext,

--- a/pages/api/policies/[policyId]/approve/mrv/[did].ts
+++ b/pages/api/policies/[policyId]/approve/mrv/[did].ts
@@ -6,10 +6,8 @@ import withAuthentication from 'src/middleware/withAuthentication'
 import withHmac from 'src/middleware/withHmac'
 import ensureRole from 'src/middleware/ensureRole'
 import { Role } from 'src/config/guardianTags'
-import exceptionFilter from 'src/middleware/exceptionFilter'
 
 export default prepare(
-	exceptionFilter,
 	onlyPut,
 	withHmac,
 	useGuardianContext,

--- a/pages/api/policies/[policyId]/approve/project/[did].ts
+++ b/pages/api/policies/[policyId]/approve/project/[did].ts
@@ -6,10 +6,8 @@ import withAuthentication from 'src/middleware/withAuthentication'
 import withHmac from 'src/middleware/withHmac'
 import ensureRole from 'src/middleware/ensureRole'
 import { Role } from 'src/config/guardianTags'
-import exceptionFilter from 'src/middleware/exceptionFilter'
 
 export default prepare(
-	exceptionFilter,
 	onlyPut,
 	withHmac,
 	useGuardianContext,

--- a/pages/api/policies/[policyId]/mrv/[mrvType].ts
+++ b/pages/api/policies/[policyId]/mrv/[mrvType].ts
@@ -6,10 +6,8 @@ import withAuthentication from 'src/middleware/withAuthentication'
 import withHmac from 'src/middleware/withHmac'
 import ensureRole from 'src/middleware/ensureRole'
 import { Role } from 'src/config/guardianTags'
-import exceptionFilter from 'src/middleware/exceptionFilter'
 
 export default prepare(
-	exceptionFilter,
 	onlyPost,
 	withHmac,
 	useGuardianContext,

--- a/pages/api/policies/[policyId]/project/index.ts
+++ b/pages/api/policies/[policyId]/project/index.ts
@@ -6,10 +6,8 @@ import withAuthentication from 'src/middleware/withAuthentication'
 import withHmac from 'src/middleware/withHmac'
 import ensureRole from 'src/middleware/ensureRole'
 import { Role } from 'src/config/guardianTags'
-import exceptionFilter from 'src/middleware/exceptionFilter'
 
 export default prepare(
-	exceptionFilter,
 	onlyPost,
 	withHmac,
 	useGuardianContext,

--- a/pages/api/policies/[policyId]/register/index.ts
+++ b/pages/api/policies/[policyId]/register/index.ts
@@ -6,10 +6,8 @@ import withAuthentication from 'src/middleware/withAuthentication'
 import withHmac from 'src/middleware/withHmac'
 import ensureRole from 'src/middleware/ensureRole'
 import { Role } from 'src/config/guardianTags'
-import exceptionFilter from 'src/middleware/exceptionFilter'
 
 export default prepare(
-	exceptionFilter,
 	onlyPost,
 	withHmac,
 	useGuardianContext,

--- a/pages/api/policies/[policyId]/role/[roleType].ts
+++ b/pages/api/policies/[policyId]/role/[roleType].ts
@@ -4,10 +4,8 @@ import useGuardianContext from 'src/context/useGuardianContext'
 import registerAccountToPolicyHandler from 'src/handler/policies/registerAccountToPolicyHandler'
 import withAuthentication from 'src/middleware/withAuthentication'
 import withHmac from 'src/middleware/withHmac'
-import exceptionFilter from 'src/middleware/exceptionFilter'
 
 export default prepare(
-	exceptionFilter,
 	onlyPost,
 	withHmac,
 	useGuardianContext,

--- a/pages/api/policies/[policyId]/trustchains/index.ts
+++ b/pages/api/policies/[policyId]/trustchains/index.ts
@@ -5,18 +5,22 @@ import withAuthentication from 'src/middleware/withAuthentication'
 import withHmac from 'src/middleware/withHmac'
 import ensureRole from 'src/middleware/ensureRole'
 import { Role } from 'src/config/guardianTags'
-import exceptionFilter from 'src/middleware/exceptionFilter'
 import onlyGet from 'src/middleware/onlyGet'
 import config from 'src/config'
 
-const isProtected = !config.publicTrustChainAccess
-const emptyHandler = (handler) => (req, res) => handler(req, res)
+const generateMiddleware = () => {
+	const base = [onlyGet, useGuardianContext]
 
-export default prepare(
-	exceptionFilter,
-	onlyGet,
-	useGuardianContext,
-	isProtected ? withHmac : emptyHandler,
-	isProtected ? withAuthentication : emptyHandler,
-	isProtected ? ensureRole(Role.STANDARD_REGISTRY) : emptyHandler
-)(trustChainsHandler)
+	if (!config.publicTrustChainAccess) {
+		return [
+			...base,
+			withHmac,
+			withAuthentication,
+			ensureRole(Role.STANDARD_REGISTRY),
+		]
+	}
+
+	return base
+}
+
+export default prepare(...generateMiddleware())(trustChainsHandler)

--- a/pages/api/policies/[policyId]/trustchains/index.ts
+++ b/pages/api/policies/[policyId]/trustchains/index.ts
@@ -7,12 +7,16 @@ import ensureRole from 'src/middleware/ensureRole'
 import { Role } from 'src/config/guardianTags'
 import exceptionFilter from 'src/middleware/exceptionFilter'
 import onlyGet from 'src/middleware/onlyGet'
+import config from 'src/config'
+
+const isProtected = !config.publicTrustChainAccess
+const emptyHandler = (handler) => (req, res) => handler(req, res)
 
 export default prepare(
 	exceptionFilter,
 	onlyGet,
-	withHmac,
 	useGuardianContext,
-	withAuthentication,
-	ensureRole(Role.STANDARD_REGISTRY)
+	isProtected ? withHmac : emptyHandler,
+	isProtected ? withAuthentication : emptyHandler,
+	isProtected ? ensureRole(Role.STANDARD_REGISTRY) : emptyHandler
 )(trustChainsHandler)

--- a/pages/api/testAuth.ts
+++ b/pages/api/testAuth.ts
@@ -1,6 +1,5 @@
 import prepare from 'src/utils/prepare'
 import TestAuthHandler from 'src/handler/testAuthHandler'
 import withHmac from 'src/middleware/withHmac'
-import exceptionFilter from 'src/middleware/exceptionFilter'
 
-export default prepare(exceptionFilter, withHmac)(TestAuthHandler)
+export default prepare(withHmac)(TestAuthHandler)

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -14,6 +14,7 @@ interface Config {
 	guardianApiUrl: string
 	registryUsername: string
 	registryPassword: string
+	publicTrustChainAccess: boolean
 }
 
 const {
@@ -31,6 +32,7 @@ const {
 	GUARDIAN_API_URL,
 	STANDARD_REGISTRY_USERNAME,
 	STANDARD_REGISTRY_PASSWORD,
+	PUBLIC_TRUST_CHAIN_ACCESS,
 } = process.env
 
 const AUTH_KEY_MIN_LENGTH = 10
@@ -56,6 +58,7 @@ const config: Config = {
 	guardianApiUrl: GUARDIAN_API_URL,
 	registryUsername: STANDARD_REGISTRY_USERNAME,
 	registryPassword: STANDARD_REGISTRY_PASSWORD,
+	publicTrustChainAccess: true, // booleanValue(PUBLIC_TRUST_CHAIN_ACCESS),
 }
 
 export default config

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -58,7 +58,7 @@ const config: Config = {
 	guardianApiUrl: GUARDIAN_API_URL,
 	registryUsername: STANDARD_REGISTRY_USERNAME,
 	registryPassword: STANDARD_REGISTRY_PASSWORD,
-	publicTrustChainAccess: true, // booleanValue(PUBLIC_TRUST_CHAIN_ACCESS),
+	publicTrustChainAccess: booleanValue(PUBLIC_TRUST_CHAIN_ACCESS),
 }
 
 export default config

--- a/src/handler/policies/trustChainsHandler.ts
+++ b/src/handler/policies/trustChainsHandler.ts
@@ -16,6 +16,8 @@ async function TrustChainsHandler(
 	let { accessToken } = req
 
 	if (config.publicTrustChainAccess) {
+		res.setHeader('Access-Control-Allow-Origin', '*')
+
 		// 😅 Impersonate the Standard registry to get the trust chain data
 		const account: AccountLoginResponse = await guardian.account.login({
 			username: config.registryUsername,

--- a/src/handler/policies/trustChainsHandler.ts
+++ b/src/handler/policies/trustChainsHandler.ts
@@ -96,7 +96,7 @@ async function TrustChainsHandler(
 			new Date(b.createDate).getTime() - new Date(a.createDate).getTime()
 	)
 
-	// // Sort each trust chain flow with the most recent last
+	// Sort each trust chain flow with the most recent last
 	mappedResponse.forEach((trustchain) => {
 		trustchain.trustChain.sort(
 			(a, b) =>

--- a/src/mappers/trustChainMapper.ts
+++ b/src/mappers/trustChainMapper.ts
@@ -2,7 +2,7 @@ import { components } from 'src/spec/openapi'
 
 type TrustChainDocument = components['schemas']['TrustChainDocument']
 
-export default (guardianTrustChainBlockData): TrustChainDocument =>
+export default (guardianTrustChainBlockData): TrustChainDocument[] =>
 	guardianTrustChainBlockData.map(
 		({ vpDocument, mintDocument, policyDocument, documents }) => ({
 			hash: vpDocument.hash,

--- a/src/utils/prepare.ts
+++ b/src/utils/prepare.ts
@@ -11,9 +11,15 @@
  *
  */
 
+import exceptionFilter from 'src/middleware/exceptionFilter'
+
+const generateMiddleware = (...fns) => [exceptionFilter, ...fns]
+
 const prepare =
 	(...fns) =>
 	(x) =>
-		fns.reverse().reduce((v, f) => f(v), x)
+		generateMiddleware(...fns)
+			.reverse()
+			.reduce((v, f) => f(v), x)
 
 export default prepare


### PR DESCRIPTION
This PR provides a new env variable that allows the trustchain API to be publically exposed so anyone could query it for a strucutred trustchain payload.

Add `PUBLIC_TRUST_CHAIN_ACCESS=TRUE` to the environment to enable