### PR TITLE
Fetch policy token

### DIFF
--- a/Guardian Middleware API.postman_collection.json
+++ b/Guardian Middleware API.postman_collection.json
@@ -1118,27 +1118,22 @@
 				{
 					"name": "Get token id for policy",
 					"request": {
-						"method": "POST",
+						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/policies/:policyId/role/:roleType",
+							"raw": "{{baseUrl}}/policies/:policyId/token",
 							"host": [
 								"{{baseUrl}}"
 							],
 							"path": [
 								"policies",
 								":policyId",
-								"role",
-								":roleType"
+								"token"
 							],
 							"variable": [
 								{
 									"key": "policyId",
 									"value": "62f27a007fe3fa7b888e8496"
-								},
-								{
-									"key": "roleType",
-									"value": "registrant"
 								}
 							]
 						}

--- a/Guardian Middleware API.postman_collection.json
+++ b/Guardian Middleware API.postman_collection.json
@@ -1,9 +1,8 @@
 {
 	"info": {
-		"_postman_id": "327b3273-7002-4520-9d37-68c387c128ff",
+		"_postman_id": "2cd803de-d61c-4005-8963-2f6c475a5a20",
 		"name": "Guardian Middleware API",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "21575808"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
@@ -1024,8 +1023,7 @@
 									"variable": [
 										{
 											"key": "policyId",
-											"value": "62f27a007fe3fa7b888e8496",
-											"type": "string"
+											"value": "62f27a007fe3fa7b888e8496"
 										}
 									]
 								}
@@ -1114,6 +1112,96 @@
 							],
 							"cookie": [],
 							"body": ""
+						}
+					]
+				},
+				{
+					"name": "Get token id for policy",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/policies/:policyId/role/:roleType",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"policies",
+								":policyId",
+								"role",
+								":roleType"
+							],
+							"variable": [
+								{
+									"key": "policyId",
+									"value": "62f27a007fe3fa7b888e8496"
+								},
+								{
+									"key": "roleType",
+									"value": "registrant"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Get token id for policy",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/policies/:policyId/token",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"policies",
+										":policyId",
+										"token"
+									],
+									"variable": [
+										{
+											"key": "policyId",
+											"value": "632b33532e11b6094416fc14"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json; charset=utf-8"
+								},
+								{
+									"key": "ETag",
+									"value": "\"2b-Xg7quyabEBSGbH1YAtO2VWZzqrs\""
+								},
+								{
+									"key": "Content-Length",
+									"value": "43"
+								},
+								{
+									"key": "Vary",
+									"value": "Accept-Encoding"
+								},
+								{
+									"key": "Date",
+									"value": "Fri, 30 Sep 2022 10:48:05 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=5"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"data\": {\n        \"policy_token_id\": \"0.0.48310942\"\n    }\n}"
 						}
 					]
 				}

--- a/pages/api/policies/[policyId]/token/index.ts
+++ b/pages/api/policies/[policyId]/token/index.ts
@@ -1,0 +1,14 @@
+import onlyGet from 'src/middleware/onlyGet'
+import prepare from 'src/utils/prepare'
+import useGuardianContext from 'src/context/useGuardianContext'
+import fetchTokenInformation from 'src/handler/policies/fetchTokenInformation'
+import withAuthentication from 'src/middleware/withAuthentication'
+import ensureRole from 'src/middleware/ensureRole'
+import { Role } from 'src/config/guardianTags'
+
+export default prepare(
+	onlyGet,
+	useGuardianContext,
+	withAuthentication,
+	ensureRole(Role.STANDARD_REGISTRY)
+)(fetchTokenInformation)

--- a/src/config/guardianTags.ts
+++ b/src/config/guardianTags.ts
@@ -34,6 +34,14 @@ export enum Tag {
 	verifiedPresentationGrid = 'vp_grid',
 
 	trustChainBlock = 'trustChainBlock',
+
+	// The Mint Token block
+	mintToken = 'mint_token',
+
+	// Path to mint token
+	verifierWorkflow = 'verifier_workflow',
+	approveIssueRequestsPage = 'approve_issue_requests_page',
+	mintTokenParent = 'mit_token',
 }
 
 export enum Role {

--- a/src/guardian/policies/index.ts
+++ b/src/guardian/policies/index.ts
@@ -31,8 +31,7 @@ const ENDPOINTS = {
 	publishFn: (policyId: string) => `/policies/${policyId}/publish`,
 	updateFn: (policyId: string) => `/policies/${policyId}`,
 	blocksFn: (policyId: string) => `/policies/${policyId}/blocks`,
-	policyInfoByIdFn: (policyId: string) =>
-		`/policies/${policyId}`,
+	policyInfoByIdFn: (policyId: string) => `/policies/${policyId}`,
 	blockByIdFn: (policyId: string, uuid: string) =>
 		`/policies/${policyId}/blocks/${uuid}`,
 	blockByTagFn: (policyId: string, tag: string) =>
@@ -93,7 +92,11 @@ const list = async (api: AxiosInstance, accessToken: string) => {
 	return result.data
 }
 
-const fetchSinglePolicy = async (api: AxiosInstance, accessToken: string, id: string) => {
+const fetchSinglePolicy = async (
+	api: AxiosInstance,
+	accessToken: string,
+	id: string
+) => {
 	const result = await api.get<Record<string, unknown>>(
 		ENDPOINTS.policyInfoByIdFn(id),
 		{
@@ -220,10 +223,7 @@ export interface Policies {
 		token: string,
 		name: string
 	) => Promise<Record<string, unknown>>
-	policyById: (
-		token: string,
-		id: string
-	) => Promise<Record<string, unknown>>
+	policyById: (token: string, id: string) => Promise<Record<string, unknown>>
 	blockById: (
 		token: string,
 		policyId: string,

--- a/src/guardian/policies/index.ts
+++ b/src/guardian/policies/index.ts
@@ -31,6 +31,8 @@ const ENDPOINTS = {
 	publishFn: (policyId: string) => `/policies/${policyId}/publish`,
 	updateFn: (policyId: string) => `/policies/${policyId}`,
 	blocksFn: (policyId: string) => `/policies/${policyId}/blocks`,
+	policyInfoByIdFn: (policyId: string) =>
+		`/policies/${policyId}`,
 	blockByIdFn: (policyId: string, uuid: string) =>
 		`/policies/${policyId}/blocks/${uuid}`,
 	blockByTagFn: (policyId: string, tag: string) =>
@@ -89,6 +91,29 @@ const list = async (api: AxiosInstance, accessToken: string) => {
 	)
 
 	return result.data
+}
+
+const fetchSinglePolicy = async (api: AxiosInstance, accessToken: string, id: string) => {
+	const result = await api.get<Record<string, unknown>>(
+		ENDPOINTS.policyInfoByIdFn(id),
+		{
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+			},
+		}
+	)
+
+	return result.data
+}
+
+const policyById = async (api: AxiosInstance, accessToken: string, id) => {
+	const policy = await fetchSinglePolicy(api, accessToken, id)
+
+	if (!policy) {
+		throw new Error('Policy was not found by id')
+	}
+
+	return policy
 }
 
 const policyByName = async (api: AxiosInstance, accessToken: string, name) => {
@@ -195,6 +220,10 @@ export interface Policies {
 		token: string,
 		name: string
 	) => Promise<Record<string, unknown>>
+	policyById: (
+		token: string,
+		id: string
+	) => Promise<Record<string, unknown>>
 	blockById: (
 		token: string,
 		policyId: string,
@@ -217,6 +246,7 @@ const policies = (api: AxiosInstance): Policies => ({
 	blocks: (token, policyId) => blocks(api, token, policyId),
 	blockByTag: (token, policyId, tag) => blockByTag(api, token, policyId, tag),
 	policyByName: (token, name) => policyByName(api, token, name),
+	policyById: (token, id) => policyById(api, token, id),
 	blockById: (token, policyId, uuid) => blockById(api, token, policyId, uuid),
 	sendToBlock: (token, policyId, uuid, payload) =>
 		sendToBlock(api, token, policyId, uuid, payload),

--- a/src/handler/policies/fetchTokenInformation.ts
+++ b/src/handler/policies/fetchTokenInformation.ts
@@ -1,0 +1,43 @@
+import { GuardianMiddlewareRequest } from 'src/context/useGuardianContext'
+import Response from 'src/response'
+import { NextApiResponse } from 'next'
+import { Tag } from 'src/config/guardianTags'
+
+async function FetchTokenInformation(
+	req: GuardianMiddlewareRequest,
+	res: NextApiResponse
+) {
+	const { accessToken } = req
+	const { policyId } = req.query
+	const { guardian } = req.context
+
+	const data = await guardian.policies.policyById(accessToken, String(policyId))
+
+	const mintTokenPath = [
+		Tag.verifierWorkflow,
+		Tag.approveIssueRequestsPage,
+		Tag.mintTokenParent,
+		Tag.mintToken,
+	]
+
+	// 😅 I feel Justyn already wrote this...
+	const traverseToBlock = (data, tagPath = []) => {
+		const tag = tagPath.shift()
+
+		if (tag) {
+			const updated = data.children.find(child => child.tag === tag)
+
+			return traverseToBlock(updated, tagPath)
+		}
+
+		return data
+	}
+
+	const block = traverseToBlock(data.config, mintTokenPath)
+
+	Response.json(res, {
+		policy_token_id: block.tokenId
+	})
+}
+
+export default FetchTokenInformation

--- a/src/handler/policies/fetchTokenInformation.ts
+++ b/src/handler/policies/fetchTokenInformation.ts
@@ -11,7 +11,10 @@ async function FetchTokenInformation(
 	const { policyId } = req.query
 	const { guardian } = req.context
 
-	const data = await guardian.policies.policyById(accessToken, String(policyId))
+	const data = await guardian.policies.policyById(
+		accessToken,
+		String(policyId)
+	)
 
 	const mintTokenPath = [
 		Tag.verifierWorkflow,
@@ -25,7 +28,7 @@ async function FetchTokenInformation(
 		const tag = tagPath.shift()
 
 		if (tag) {
-			const updated = data.children.find(child => child.tag === tag)
+			const updated = data.children.find((child) => child.tag === tag)
 
 			return traverseToBlock(updated, tagPath)
 		}
@@ -36,7 +39,7 @@ async function FetchTokenInformation(
 	const block = traverseToBlock(data.config, mintTokenPath)
 
 	Response.json(res, {
-		policy_token_id: block.tokenId
+		policy_token_id: block.tokenId,
 	})
 }
 

--- a/src/spec/openapi.json
+++ b/src/spec/openapi.json
@@ -956,7 +956,7 @@
 			}
 		},
 		"/policies/{policyId}/token": {
-			"post": {
+			"get": {
 				"tags": ["policies"],
 				"summary": "Get the token id connected to a policy",
 				"parameters": [

--- a/src/spec/openapi.json
+++ b/src/spec/openapi.json
@@ -955,6 +955,68 @@
 				}
 			}
 		},
+		"/policies/{policyId}/token": {
+			"post": {
+				"tags": ["policies"],
+				"summary": "Get the token id connected to a policy",
+				"parameters": [
+					{
+						"name": "policyId",
+						"in": "path",
+						"schema": {
+							"type": "string"
+						},
+						"required": true,
+						"example": "62d98142a8075c6027dfcf90"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"headers": {
+							"Date": {
+								"schema": {
+									"type": "string",
+									"example": "Mon, 25 Jul 2022 16:08:13 GMT"
+								}
+							},
+							"Connection": {
+								"schema": {
+									"type": "string",
+									"example": "keep-alive"
+								}
+							},
+							"Keep-Alive": {
+								"schema": {
+									"type": "string",
+									"example": "timeout=5"
+								}
+							},
+							"Transfer-Encoding": {
+								"schema": {
+									"type": "string",
+									"example": "chunked"
+								}
+							}
+						},
+						"content": {
+							"text/plain": {
+								"schema": {
+									"type": "string"
+								},
+								"example": null
+							}
+						}
+					},
+					"422": {
+						"$ref": "#/components/responses/422"
+					},
+					"401": {
+						"$ref": "#/components/responses/401"
+					}
+				}
+			}
+		},
 		"/policies/{policyId}/mrv/{mrv_type}": {
 			"post": {
 				"tags": ["policies"],

--- a/src/spec/openapi.ts
+++ b/src/spec/openapi.ts
@@ -112,6 +112,31 @@ export interface paths {
 			}
 		}
 	}
+	'/policies/{policyId}/token': {
+		post: {
+			parameters: {
+				path: {
+					policyId: string
+				}
+			}
+			responses: {
+				/** OK */
+				200: {
+					headers: {
+						Date?: string
+						Connection?: string
+						'Keep-Alive'?: string
+						'Transfer-Encoding'?: string
+					}
+					content: {
+						'text/plain': string
+					}
+				}
+				401: components['responses']['401']
+				422: components['responses']['422']
+			}
+		}
+	}
 	'/policies/{policyId}/mrv/{mrv_type}': {
 		post: {
 			parameters: {


### PR DESCRIPTION
## Overview

Adds a new endpoint to fetch the token id for a given policy.

### Endpoint

GET `{{baseUrl}}/policies/:policyId/token`

### Response

```
{
    "data": {
        "policy_token_id": "0.0.48310942"
    }
}
```

See updated documentation for more information, the current constraints are:

- Need to be auth'd as standard registry 
- No HMAC requirement

If this is a feature that is important to external explorers or other service providers I will be happy to remove the authentication dependency and impersonate the standard registry to return the token ID.