### PR TITLE
[Improvement/347] Update to use v2 policy documents

### DIFF
--- a/__tests__/e2e/fullAgrecalcPolicy.test.ts
+++ b/__tests__/e2e/fullAgrecalcPolicy.test.ts
@@ -113,15 +113,15 @@ describe('Test Agrecalc policy flow', () => {
 			)
 
 			const data = {
-				field0: `Project ${isoDate}`,
-				field1: 'Project Location',
-				field2: 57779,
-				field3: 'Illum commodi quidem dolorem voluptatibus.',
-				field4: 'Porro qui error earum quia iure praesentium molestiae.',
-				field5: 'Aut necessitatibus voluptatem quae nemo reiciendis officia et aperiam quia.',
-				field6: 'Quia maiores vel et reprehenderit eius fugiat quae nihil.',
-				field7: 'Aliquid et sint sint assumenda nostrum eum.',
-				field8: 'Quia explicabo dolorum minima perspiciatis suscipit odit explicabo aut amet.',
+				field0: `Matt Farm ${isoDate}`,
+				field1: 'Paignton',
+				field2: 420,
+				field3: 'Fancy Soil',
+				field4: 'A Cat',
+				field5: 'We grow grass',
+				field6: 'No we do not',
+				field7: 'No, we do not...',
+				field8: 'No',
 			}
 
 			const response = await hmacAxios.post(
@@ -170,28 +170,19 @@ describe('Test Agrecalc policy flow', () => {
 			)
 
 			const data = {
-				field0: 'uuid13',
-				field1: `Project ${isoDate}`,
-				field2: 'Project description',
-				field3: registrant,
-				field4: {
-					field0: 'dovu.market',
-					field1: 'England',
-					field2: 'Micro',
-				},
-				field5: {
-					field0: 'uuid',
-					field1: 'GeoJSON Location',
-					field2: 'Removal',
-					field3: 'N/A',
-					field4: 'N/A',
-					field5: 'N/A',
-					field6: 1,
-					field7: 'N/A',
-					field8: 'Developer of project',
-					field9: 'Sponsor (optional)',
-					field10: 'Claim Tokens (number)',
-				},
+				field0: '1234',
+				field1: `Matt's Farm ${isoDate}`,
+				field2: "This is a description about Matt's farm",
+				field3: 'Matt Smithies',
+				field4: 'Ecological Project Info - Link to Project Data',
+				field5: 'Ecological Project Info - Country: The host country for the project',
+				field6: 'Ecological Project Info - Project Scale: One from the list of - Micro, Small, Medium, or Large',
+				field7: 'Modular Benefit Project - Unique identifier ',
+				field8: 'Modular Benefit Project - Geographic Location',
+				field9: 'Modular Benefit Project - Targeted Benefit Type',
+				field10: 'Modular Benefit Project - Developer(s)',
+				field11: 'Modular Benefit Project - Sponsor(s)',
+				field12: 'Modular Benefit Project - Claim Tokens',
 			}
 
 			const response = await hmacAxios.post(
@@ -241,20 +232,11 @@ describe('Test Agrecalc policy flow', () => {
 
 			const data = {
 				field0: 100,
-				field1: 200,
-				field2: 300,
-				field3: 400,
-				field4: 500,
-				field5: 600,
-				field6: 700,
-				field7: 800,
-				field8: 900,
-				field9: 1000,
-				field10: 1100,
-				field11: 1200,
-				field12: 1300,
-				field13: 1400,
-				field14: 1500,
+				field1: 100,
+				field2: 100,
+				field3: 100,
+				field4: 100,
+				field5: 100,
 			}
 
 			const response = await hmacAxios.post(

--- a/__tests__/e2e/fullCoolFarmPolicy.test.ts
+++ b/__tests__/e2e/fullCoolFarmPolicy.test.ts
@@ -113,15 +113,15 @@ describe('Test Cool Farm policy flow', () => {
 			)
 
 			const data = {
-				field0: `Project ${isoDate}`,
-				field1: 'Project Location',
-				field2: 57779,
-				field3: 'Illum commodi quidem dolorem voluptatibus.',
-				field4: 'Porro qui error earum quia iure praesentium molestiae.',
-				field5: 'Aut necessitatibus voluptatem quae nemo reiciendis officia et aperiam quia.',
-				field6: 'Quia maiores vel et reprehenderit eius fugiat quae nihil.',
-				field7: 'Aliquid et sint sint assumenda nostrum eum.',
-				field8: 'Quia explicabo dolorum minima perspiciatis suscipit odit explicabo aut amet.',
+				field0: `Matt Farm ${isoDate}`,
+				field1: 'Paignton',
+				field2: 420,
+				field3: 'Fancy Soil',
+				field4: 'A Cat',
+				field5: 'We grow grass',
+				field6: 'No we do not',
+				field7: 'No, we do not...',
+				field8: 'No',
 			}
 
 			const response = await hmacAxios.post(
@@ -170,28 +170,19 @@ describe('Test Cool Farm policy flow', () => {
 			)
 
 			const data = {
-				field0: 'uuid13',
-				field1: `Project ${isoDate}`,
-				field2: 'Project description',
-				field3: registrant,
-				field4: {
-					field0: 'dovu.market',
-					field1: 'England',
-					field2: 'Micro',
-				},
-				field5: {
-					field0: 'uuid',
-					field1: 'GeoJSON Location',
-					field2: 'Removal',
-					field3: 'N/A',
-					field4: 'N/A',
-					field5: 'N/A',
-					field6: 1,
-					field7: 'N/A',
-					field8: 'Developer of project',
-					field9: 'Sponsor (optional)',
-					field10: 'Claim Tokens (number)',
-				},
+				field0: '1234',
+				field1: `Matt's Farm ${isoDate}`,
+				field2: "This is a description about Matt's farm",
+				field3: 'Matt Smithies',
+				field4: 'Ecological Project Info - Link to Project Data',
+				field5: 'Ecological Project Info - Country: The host country for the project',
+				field6: 'Ecological Project Info - Project Scale: One from the list of - Micro, Small, Medium, or Large',
+				field7: 'Modular Benefit Project - Unique identifier ',
+				field8: 'Modular Benefit Project - Geographic Location',
+				field9: 'Modular Benefit Project - Targeted Benefit Type',
+				field10: 'Modular Benefit Project - Developer(s)',
+				field11: 'Modular Benefit Project - Sponsor(s)',
+				field12: 'Modular Benefit Project - Claim Tokens',
 			}
 
 			const response = await hmacAxios.post(
@@ -240,11 +231,11 @@ describe('Test Cool Farm policy flow', () => {
 			)
 
 			const data = {
-				field0: `Test MRV Field 1 ${isoDate}`,
-				field1: 100,
-				field2: 'Test MRV Field 3',
-				field3: 200,
-				field4: 300,
+				field0: `Grass ${isoDate}`,
+				field1: 2022,
+				field2: 'N/A',
+				field3: 1000,
+				field4: 70170,
 			}
 
 			const response = await hmacAxios.post(

--- a/src/spec/openapi.json
+++ b/src/spec/openapi.json
@@ -298,22 +298,28 @@
 					{
 						"properties": {
 							"field0": {
-								"type": "number"
+								"type": "number",
+								"description": "Total CO2e emissions from farming"
 							},
 							"field1": {
-								"type": "number"
+								"type": "number",
+								"description": "CARBON SEQUESTRATION (soil) - Total CO2e from soil carbon sequestration"
 							},
 							"field2": {
-								"type": "number"
+								"type": "number",
+								"description": "Total CO2e emissions from farming (inc. Soil Carbon) "
 							},
 							"field3": {
-								"type": "number"
+								"type": "number",
+								"description": "(Mintable KGs) Net emissions from land use (inc SoilCarbon) "
 							},
 							"field4": {
-								"type": "number"
+								"type": "number",
+								"description": "Emissions per hectare (inc. Soil Carbon)"
 							},
 							"field5": {
-								"type": "number"
+								"type": "number",
+								"description": "Farm and enterprise output - KG"
 							}
 						},
 						"required": [
@@ -328,19 +334,24 @@
 					{
 						"properties": {
 							"field0": {
-								"type": "string"
+								"type": "string",
+								"description": "Crop type"
 							},
 							"field1": {
-								"type": "number"
+								"type": "number",
+								"description": "Year / Vintage"
 							},
 							"field2": {
-								"type": "string"
+								"type": "string",
+								"description": "Farm-gate amount (crop output weight)"
 							},
 							"field3": {
-								"type": "number"
+								"type": "number",
+								"description": "Emission yield per Ha"
 							},
 							"field4": {
-								"type": "number"
+								"type": "number",
+								"description": "Negative GHG KG Emissions (Mintable KG)"
 							}
 						},
 						"required": [

--- a/src/spec/openapi.json
+++ b/src/spec/openapi.json
@@ -186,98 +186,58 @@
 						"type": "string",
 						"description": "Owners of the project, can be account_id, did, or something non-PII"
 					},
+
 					"field4": {
-						"type": "object",
-						"description": "Ecological Project Information",
-						"properties": {
-							"field0": {
-								"type": "string",
-								"description": "Link to Project Data: A verified link to more project data like marketing materials or a website"
-							},
-							"field1": {
-								"type": "string",
-								"description": "Country: The host country for the project"
-							},
-							"field2": {
-								"type": "string",
-								"description": "Project Scale: One from the list of - Micro, Small, Medium, or Large"
-							}
-						}
+						"type": "string",
+						"description": "Ecological Project Info - Link to Project Data: A verified link to more project data like marketing materials or a website"
 					},
 					"field5": {
-						"type": "object",
-						"description": "Ecological Project Information",
-						"properties": {
-							"field0": {
-								"type": "string",
-								"description": "Unique identifier (“Id”): An identifier that is issued and is independent of the project. The Id is used to establish a compound identifier linking the MBP with its host EP."
-							},
-							"field1": {
-								"type": "string",
-								"description": "Geographic Location (GeoJSON for Projects, Basic GNS/GPS for Programs)"
-							},
-							"field2": {
-								"type": "string",
-								"description": "Targeted Benefit Type"
-							},
-							"field3": {
-								"type": "string",
-								"description": "Carbon (Reduction/Removal + Natural/Technology)"
-							},
-							"field4": {
-								"type": "string",
-								"description": "Water"
-							},
-							"field5": {
-								"type": "string",
-								"description": "Nitrogen"
-							},
-							"field6": {
-								"type": "string",
-								"description": "Phosphorus"
-							},
-							"field7": {
-								"type": "string",
-								"description": "Sediment"
-							},
-							"field8": {
-								"type": "string",
-								"description": "Developer(s)"
-							},
-							"field9": {
-								"type": "string",
-								"description": "Sponsor(s)"
-							},
-							"field10": {
-								"type": "string",
-								"description": "Claim Tokens"
-							}
-						}
+						"type": "string",
+						"description": "Ecological Project Info - Country: The host country for the project"
+					},
+					"field6": {
+						"type": "string",
+						"description": "Ecological Project Info - Project Scale: One from the list of - Micro, Small, Medium, or Large"
+					},
+					"field7": {
+						"type": "string",
+						"description": "Modular Benefit Project - Unique identifier (“Id”): An identifier that is issued and is independent of the project. The Id is used to establish a compound identifier linking the MBP with its host EP."
+					},
+					"field8": {
+						"type": "string",
+						"description": "Modular Benefit Project - Geographic Location (GeoJSON for Projects, Basic GNS/GPS for Programs)"
+					},
+					"field9": {
+						"type": "string",
+						"description": "Modular Benefit Project - Targeted Benefit Type"
+					},
+					"field10": {
+						"type": "string",
+						"description": "Modular Benefit Project - Developer(s)"
+					},
+					"field11": {
+						"type": "string",
+						"description": "Modular Benefit Project - Sponsor(s)"
+					},
+					"field12": {
+						"type": "string",
+						"description": "Modular Benefit Project - Claim Tokens"
 					}
 				},
 				"example": {
-					"field0": "uuid",
-					"field1": "Illum commodi quidem dolorem voluptatibus.",
-					"field2": "A at mollitia corporis molestiae ut debitis.",
-					"field3": "owner",
-					"field4": {
-						"field0": "dovu.market",
-						"field1": "England",
-						"field2": "Micro"
-					},
-					"field5": {
-						"field0": "uuid",
-						"field1": "GeoJSON Location",
-						"field2": "Removal",
-						"field3": "N/A",
-						"field4": "N/A",
-						"field5": "N/A",
-						"field6": "N/A",
-						"field7": "N/A",
-						"field8": "Developer of project",
-						"field9": "Sponsor (optional)",
-						"field10": "Claim Tokens (number)"
-					}
+					"field0": "1234",
+					"field1": "Matt's Farm",
+					"field2": "This is a description about Matt's farm",
+					"field3": "Matt Smithies",
+					"field4": "Ecological Project Info - Link to Project Data",
+					"field5": "Ecological Project Info - Country: The host country for the project",
+					"field6": "Ecological Project Info - Project Scale: One from the list of - Micro, Small, Medium, or Large",
+					"field7": "Modular Benefit Project - Unique identifier ",
+					"field8": "Modular Benefit Project - Geographic Location",
+					"field9": "Modular Benefit Project - Targeted Benefit Type",
+					"field10": "Modular Benefit Project - Developer(s)",
+					"field11": "Modular Benefit Project - Sponsor(s)",
+					"field12": "Modular Benefit Project - Claim Tokens"
 				}
 			},
 			"ProjectRegistration": {
@@ -354,33 +314,6 @@
 							},
 							"field5": {
 								"type": "number"
-							},
-							"field6": {
-								"type": "number"
-							},
-							"field7": {
-								"type": "number"
-							},
-							"field8": {
-								"type": "number"
-							},
-							"field9": {
-								"type": "number"
-							},
-							"field10": {
-								"type": "number"
-							},
-							"field11": {
-								"type": "number"
-							},
-							"field12": {
-								"type": "number"
-							},
-							"field13": {
-								"type": "number"
-							},
-							"field14": {
-								"type": "number"
 							}
 						},
 						"required": [
@@ -389,16 +322,7 @@
 							"field2",
 							"field3",
 							"field4",
-							"field5",
-							"field6",
-							"field7",
-							"field8",
-							"field9",
-							"field10",
-							"field11",
-							"field12",
-							"field13",
-							"field14"
+							"field5"
 						]
 					},
 					{

--- a/src/spec/openapi.ts
+++ b/src/spec/openapi.ts
@@ -301,28 +301,19 @@ export interface components {
 		}
 		/**
 		 * @example {
-		 *   "field0": "uuid",
-		 *   "field1": "Illum commodi quidem dolorem voluptatibus.",
-		 *   "field2": "A at mollitia corporis molestiae ut debitis.",
-		 *   "field3": "owner",
-		 *   "field4": {
-		 *     "field0": "dovu.market",
-		 *     "field1": "England",
-		 *     "field2": "Micro"
-		 *   },
-		 *   "field5": {
-		 *     "field0": "uuid",
-		 *     "field1": "GeoJSON Location",
-		 *     "field2": "Removal",
-		 *     "field3": "N/A",
-		 *     "field4": "N/A",
-		 *     "field5": "N/A",
-		 *     "field6": "N/A",
-		 *     "field7": "N/A",
-		 *     "field8": "Developer of project",
-		 *     "field9": "Sponsor (optional)",
-		 *     "field10": "Claim Tokens (number)"
-		 *   }
+		 *   "field0": "1234",
+		 *   "field1": "Matt's Farm",
+		 *   "field2": "This is a description about Matt's farm",
+		 *   "field3": "Matt Smithies",
+		 *   "field4": "Ecological Project Info - Link to Project Data",
+		 *   "field5": "Ecological Project Info - Country: The host country for the project",
+		 *   "field6": "Ecological Project Info - Project Scale: One from the list of - Micro, Small, Medium, or Large",
+		 *   "field7": "Modular Benefit Project - Unique identifier ",
+		 *   "field8": "Modular Benefit Project - Geographic Location",
+		 *   "field9": "Modular Benefit Project - Targeted Benefit Type",
+		 *   "field10": "Modular Benefit Project - Developer(s)",
+		 *   "field11": "Modular Benefit Project - Sponsor(s)",
+		 *   "field12": "Modular Benefit Project - Claim Tokens"
 		 * }
 		 */
 		EcologicalProject: {
@@ -334,40 +325,24 @@ export interface components {
 			field2?: string
 			/** @description Owners of the project, can be account_id, did, or something non-PII */
 			field3?: string
-			/** @description Ecological Project Information */
-			field4?: {
-				/** @description Link to Project Data: A verified link to more project data like marketing materials or a website */
-				field0?: string
-				/** @description Country: The host country for the project */
-				field1?: string
-				/** @description Project Scale: One from the list of - Micro, Small, Medium, or Large */
-				field2?: string
-			}
-			/** @description Ecological Project Information */
-			field5?: {
-				/** @description Unique identifier (“Id”): An identifier that is issued and is independent of the project. The Id is used to establish a compound identifier linking the MBP with its host EP. */
-				field0?: string
-				/** @description Geographic Location (GeoJSON for Projects, Basic GNS/GPS for Programs) */
-				field1?: string
-				/** @description Targeted Benefit Type */
-				field2?: string
-				/** @description Carbon (Reduction/Removal + Natural/Technology) */
-				field3?: string
-				/** @description Water */
-				field4?: string
-				/** @description Nitrogen */
-				field5?: string
-				/** @description Phosphorus */
-				field6?: string
-				/** @description Sediment */
-				field7?: string
-				/** @description Developer(s) */
-				field8?: string
-				/** @description Sponsor(s) */
-				field9?: string
-				/** @description Claim Tokens */
-				field10?: string
-			}
+			/** @description Ecological Project Info - Link to Project Data: A verified link to more project data like marketing materials or a website */
+			field4?: string
+			/** @description Ecological Project Info - Country: The host country for the project */
+			field5?: string
+			/** @description Ecological Project Info - Project Scale: One from the list of - Micro, Small, Medium, or Large */
+			field6?: string
+			/** @description Modular Benefit Project - Unique identifier (“Id”): An identifier that is issued and is independent of the project. The Id is used to establish a compound identifier linking the MBP with its host EP. */
+			field7?: string
+			/** @description Modular Benefit Project - Geographic Location (GeoJSON for Projects, Basic GNS/GPS for Programs) */
+			field8?: string
+			/** @description Modular Benefit Project - Targeted Benefit Type */
+			field9?: string
+			/** @description Modular Benefit Project - Developer(s) */
+			field10?: string
+			/** @description Modular Benefit Project - Sponsor(s) */
+			field11?: string
+			/** @description Modular Benefit Project - Claim Tokens */
+			field12?: string
 		}
 		/**
 		 * @example {
@@ -410,15 +385,6 @@ export interface components {
 					field3: number
 					field4: number
 					field5: number
-					field6: number
-					field7: number
-					field8: number
-					field9: number
-					field10: number
-					field11: number
-					field12: number
-					field13: number
-					field14: number
 			  }
 			| {
 					field0: string

--- a/src/spec/openapi.ts
+++ b/src/spec/openapi.ts
@@ -113,7 +113,7 @@ export interface paths {
 		}
 	}
 	'/policies/{policyId}/token': {
-		post: {
+		get: {
 			parameters: {
 				path: {
 					policyId: string
@@ -404,18 +404,29 @@ export interface components {
 		}
 		MeasurementReportingVerification:
 			| {
+					/** @description Total CO2e emissions from farming */
 					field0: number
+					/** @description CARBON SEQUESTRATION (soil) - Total CO2e from soil carbon sequestration */
 					field1: number
+					/** @description Total CO2e emissions from farming (inc. Soil Carbon) */
 					field2: number
+					/** @description (Mintable KGs) Net emissions from land use (inc SoilCarbon) */
 					field3: number
+					/** @description Emissions per hectare (inc. Soil Carbon) */
 					field4: number
+					/** @description Farm and enterprise output - KG */
 					field5: number
 			  }
 			| {
+					/** @description Crop type */
 					field0: string
+					/** @description Year / Vintage */
 					field1: number
+					/** @description Farm-gate amount (crop output weight) */
 					field2: string
+					/** @description Emission yield per Ha */
 					field3: number
+					/** @description Negative GHG KG Emissions (Mintable KG) */
 					field4: number
 			  }
 		TrustChains: components['schemas']['TrustChainDocument'][]

--- a/src/validators/validateEcologicalProjectSubmission.ts
+++ b/src/validators/validateEcologicalProjectSubmission.ts
@@ -8,28 +8,15 @@ const schema = Joi.object<EcologicalProject>({
 	field1: Joi.string().required(),
 	field2: Joi.string().required(),
 	field3: Joi.string().required(),
-	field4: Joi.object()
-		.keys({
-			field0: Joi.string().required(),
-			field1: Joi.string().required(),
-			field2: Joi.string().required(),
-		})
-		.required(),
-	field5: Joi.object()
-		.keys({
-			field0: Joi.string().required(),
-			field1: Joi.string().required(),
-			field2: Joi.string().required(),
-			field3: Joi.string().required(),
-			field4: Joi.string().required(),
-			field5: Joi.string().required(),
-			field6: Joi.number().required(),
-			field7: Joi.string().required(),
-			field8: Joi.string().required(),
-			field9: Joi.string().required(),
-			field10: Joi.string().required(),
-		})
-		.required(),
+	field4: Joi.string().required(),
+	field5: Joi.string().required(),
+	field6: Joi.string().required(),
+	field7: Joi.string().required(),
+	field8: Joi.string().required(),
+	field9: Joi.string().required(),
+	field10: Joi.string().required(),
+	field11: Joi.string().required(),
+	field12: Joi.string().required(),
 })
 
 export default (candidate: EcologicalProject): Array<string> | void => {

--- a/src/validators/validateMrvDocumentSubmission.ts
+++ b/src/validators/validateMrvDocumentSubmission.ts
@@ -20,15 +20,6 @@ const agrecalcSchema = Joi.object<MeasurementReportingVerification>({
 	field3: Joi.number().required(),
 	field4: Joi.number().required(),
 	field5: Joi.number().required(),
-	field6: Joi.number().required(),
-	field7: Joi.number().required(),
-	field8: Joi.number().required(),
-	field9: Joi.number().required(),
-	field10: Joi.number().required(),
-	field11: Joi.number().required(),
-	field12: Joi.number().required(),
-	field13: Joi.number().required(),
-	field14: Joi.number().required(),
 })
 
 const getSchemaFromPath = (mrvType: string) => {


### PR DESCRIPTION
Fixes [#347](https://dovu.atlassian.net/jira/software/projects/DOVU/boards/6?selectedIssue=DOVU-347)
=

This PR brings the API inline with the new v2 policy documents [published by DOVU](https://github.com/dovuofficial/guardian-policies/tree/main/policies).

Updates in this PR affect the following form submissions:
- Agrecalc MRV submission fields
- Ecological Project submission fields

This includes validation upon `POST`ing to the API and updates to the Postman API docs.

## Acceptance Criteria
- [x] Full end to end tests of both Agrecalc and Cool Farm Tool policies pass against Guardian v2.3.1