### PR TITLE
Add filter for ensuring valid positive mint amounts for MRV trustchains

### DIFF
--- a/src/mappers/trustChainMapper.ts
+++ b/src/mappers/trustChainMapper.ts
@@ -56,4 +56,4 @@ export default (guardianTrustChainBlockData): TrustChainDocument[] =>
 				})
 			),
 		})
-	)
+	).filter(item => !!parseFloat(item.mintAmount))

--- a/src/mappers/trustChainMapper.ts
+++ b/src/mappers/trustChainMapper.ts
@@ -3,8 +3,8 @@ import { components } from 'src/spec/openapi'
 type TrustChainDocument = components['schemas']['TrustChainDocument']
 
 export default (guardianTrustChainBlockData): TrustChainDocument[] =>
-	guardianTrustChainBlockData.map(
-		({ vpDocument, mintDocument, policyDocument, documents }) => ({
+	guardianTrustChainBlockData
+		.map(({ vpDocument, mintDocument, policyDocument, documents }) => ({
 			hash: vpDocument.hash,
 			tokenId: mintDocument.tokenId,
 			mintDate: mintDocument.date,
@@ -55,5 +55,5 @@ export default (guardianTrustChainBlockData): TrustChainDocument[] =>
 					type: document.type,
 				})
 			),
-		})
-	).filter(item => !!parseFloat(item.mintAmount))
+		}))
+		.filter((item) => !!parseFloat(item.mintAmount))


### PR DESCRIPTION
## Overview

To avoid displaying entries as 0 minted tokens in the trustchain elements as they aren't useful to display, I'd rather not reissue the policy and tokens again for DOVU production as this would be undesirable on ledgerworks ESG explorer.

## Illustration off issue

![Screenshot 2023-01-05 at 15 00 44](https://user-images.githubusercontent.com/6974163/210810570-2674db6c-d443-48a5-8b40-25adc454f6fb.png)

## Fix

Filter out, non-positive/zero mints of carbon to be visible from exposed trustchain after mapping of data has taken place.




